### PR TITLE
fix content management policy watermark

### DIFF
--- a/rebuildexec/policy.go
+++ b/rebuildexec/policy.go
@@ -48,7 +48,7 @@ type XmlConfig struct {
 */
 
 type Pdfcontentmanagement struct {
-	Watermark          string      `json:"watermark" xml:"watermark"`
+	Watermark          string      `json:"Watermark" xml:"watermark"`
 	Metadata           json.Number `json:"Metadata" xml:"metadata"`
 	InternalHyperlinks json.Number `json:"InternalHyperlinks" xml:"internal_hyperlinks"`
 	ExternalHyperlinks json.Number `json:"ExternalHyperlinks" xml:"external_hyperlinks"`

--- a/rebuildexec/policy.go
+++ b/rebuildexec/policy.go
@@ -48,7 +48,7 @@ type XmlConfig struct {
 */
 
 type Pdfcontentmanagement struct {
-	Watermark          json.Number `json:"-" xml:"watermark,omitempty"`
+	Watermark          string      `json:"watermark" xml:"watermark"`
 	Metadata           json.Number `json:"Metadata" xml:"metadata"`
 	InternalHyperlinks json.Number `json:"InternalHyperlinks" xml:"internal_hyperlinks"`
 	ExternalHyperlinks json.Number `json:"ExternalHyperlinks" xml:"external_hyperlinks"`


### PR DESCRIPTION
if there is  watermark attribute like   "Watermark": "Processed"  it will show the "Processed" watermark on the pdf file

if the  watermark attribute is empty like    "Watermark": ""   or the watermark attribute is not present  then the processed pdf file will not have any watermark